### PR TITLE
Update `exclude_patterns` for DeepSource

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,9 @@
 version = 1
 
+exclude_patterns = [
+  "**/static/**"
+]
+
 [[analyzers]]
 name = "python"
 enabled = true


### PR DESCRIPTION
We noticed that you reported a false positive. We found out that you are analyzing static content which is based on third-party modules and browser-based. We don't detect browser-based plugins so, you can use `#skipcq` over the line or on the line. It can resolve the intentional occurrences.

Signed-off-by: Moulik Aggarwal <moulik@deepsource.io>